### PR TITLE
feat(schema): Implement oneOf discriminated union support for tool schemas

### DIFF
--- a/.tasks.org
+++ b/.tasks.org
@@ -46,10 +46,10 @@
          The data model already parses CLOSED tags,
          so the implementation should focus on updating the header's properties during status changes
          and ensuring this is reflected in both the in-memory structure and the persisted org file.
-     - [x] Identify where status transitions occur in the code (e.g., from TODO/PROG to DONE).
-     - [x] Implement logic during status transitions to set CLOSED to the current timestamp.
-     - [x] Write unit tests to validate that the CLOSED tag logic works properly.
-     - [x] Document implementation details and edge cases in project documentation.
+       - [x] Identify where status transitions occur in the code (e.g., from TODO/PROG to DONE).
+       - [x] Implement logic during status transitions to set CLOSED to the current timestamp.
+       - [x] Write unit tests to validate that the CLOSED tag logic works properly.
+       - [x] Document implementation details and edge cases in project documentation.
 **** TODO modification of properties
      :PROPERTIES:
      :ID: 55803461
@@ -236,9 +236,9 @@
          Will update logic to set status to PROG if any checkbox is checked,
          and further synchronize with checkbox state.
          Planning to ensure thorough unit testing for any changes.
-     - [x] Change header status automatically from =NEXT=/=TODO= to =PROG= if a single checkbox is set
-     - [x] Change header status to =DONE= if =CheckProgress= has =Done()= as true.
-     - [x] Unit test new functionality
+       - [x] Change header status automatically from =NEXT=/=TODO= to =PROG= if a single checkbox is set
+       - [x] Change header status to =DONE= if =CheckProgress= has =Done()= as true.
+       - [x] Unit test new functionality
 *** PROG Bullet children [4/7]
     SCHEDULED: <2026-01-26 Mon> DEADLINE: <2026-02-02 Mon>
     :PROPERTIES:
@@ -506,7 +506,7 @@
     - [ ] Create ~export_to_notion~ MCP tool.
     - [ ] Implement unit tests for the block converter.
     - [ ] Integration tests with a test Notion workspace.
-** PROG Tool Design & AI UX Improvements [3/9] :ux:ui:design:
+** PROG Tool Design & AI UX Improvements [3/13] :ux:ui:design:
    :PROPERTIES:
    :ID: 30384709
    :END:
@@ -515,6 +515,8 @@
    - [ ] Improve tool documentation/schemas to explicitly suggest bulk operations for better token efficiency and state consistency.
    - [ ] Implement an ~output_format~ flag for ~query_items~ supporting CSV (default), Markdown, and Raw (Org) to allow switching between machine-efficient and human-readable views.
    - [ ] Quiet down CLI output for ~embed~ and other commands: use summaries or progress bars instead of full table dumps.
+   - [ ] *Design Decision*: Refactor `manage_*` tools to use "Atomic Union" schemas (Method-based sub-schemas) instead of splitting tools. Preserves atomicity while increasing strictness.
+   - [ ] *Design Decision*: Extract movement logic into a generic `move_item` tool that works for any `Render` node. Remove movement methods from `manage_bullet`.
 *** DONE Response Metadata Enhancement [9/9]
     CLOSED: [2026-02-15 Sun 21:47]
     :PROPERTIES:
@@ -558,6 +560,20 @@
     - [ ] *Source of Truth*: `OrgFileFromReader` in `orgmcp/file.go` has a hardcoded `fmt.Fprintf(os.Stderr, "%s", PrintTable(...))` call.
     - [ ] *Technical Constraint*: MCP server protocol expects a clean `stdout`. Currently, `os.Stderr` is being flooded with table dumps, making logs hard to read and potentially causing issues in some environments.
     - [ ] *Proposed Change*: Replace the full table dump with a one-line summary unless a `--verbose` flag is provided to the CLI.
+*** TODO Issue-17 feat: Temporary UIDs for atomic multi-operation tool calls :issue:17:mcp:ux:memory::
+    :PROPERTIES:
+    :ID: 30379703
+    :END:
+    - [ ] *Gap*: Currently, adding an item in a `manage_*` call does not update the `OrgFile.items` map in-memory for that same call. This prevents subsequent operations (like adding a child to the newly created item) within the same tool execution.
+    - [ ] *Proposal*: When an item is added, generate a temporary UID (e.g., `temp:rand8`) and register it in the `items` map immediately. This allows the tool to reference the new item for the remainder of the call.
+    - [ ] *Decision Resolved: Temporary UIDs (AI-Specified)*: AI can specify a `temp_uid` (e.g., `temp:new-header`) in an `add` operation. This ID is registered in the in-memory `items` map immediately, allowing subsequent operations in the same call to reference it. Not persisted to disk.
+    * *Technical Design: Temporary IDs (AI-Only)*: Implement `temp:[random]` prefix for in-memory-only addressing. UIDs are valid only for the duration of a single `tools/call` JSON-RPC execution.
+    * *Implementation*: `OrgFile.RegisterTemp(Render) Uid` will be called during `AddChildren`. `GetUid` will resolve both stable and `temp:` prefixed IDs.
+*** TODO Issue-18 feat: Implement oneOf/Discriminated Union schema generation for strict AI tool schemas :issue:18:schema:mcp:ai::
+    :PROPERTIES:
+    :ID: 40413358
+    :END:
+    [[https://github.com/P3rtang/org-mcp/issues/18]]
 ** DONE Tag Management & Discovery Improvements
    CLOSED: [2026-02-14 Sat 14:30]
    :PROPERTIES:
@@ -618,6 +634,10 @@
    - [x] *Decision Resolved: Surgical Addressing*: Dedicated `read_table` tool for complex queries (row/col ranges). `manage_table` uses coordinate-based (R,C) addressing to keep queries surgical and token-efficient.
    - [x] *Decision Resolved: Alignment Strategy*: The `Render()` method will *always* auto-format with correct column widths. Correctness and human-readability are prioritized over minimal diff noise.
    - [x] *Decision Resolved: Parsing Fluidity*: `OrgFileFromReader` and `ParseIndentedLine` will both detect `|` as a structural marker. Tables are first-class `Render` nodes, capable of being children of `Header` or `Bullet`.
+   - [ ] *Strategic Gap*: `OrgFileFromReader` panics on top-level text. High priority fix.
+   - [ ] *Strategic Gap*: `items` map doesn't sync after `add` operations. Fix required for 'Temporary IDs'.
+   - [ ] *Design Decision*: Support `#+NAME` as a stable UID for Tables.
+   - [x] *Decision Resolved: Naming Stability*: `#+NAME` is the primary UID. If the user changes it, the AI must re-discover it via `query_items`. Not a system-level concern.
 ** Requirement Distillation
    :PROPERTIES:
    :ID: 17984267
@@ -625,6 +645,10 @@
    * *Functional*: Reading/Writing Org tables via MCP tools. Support for CSV-style addressing (e.g., `row:1, col:2`).
    * *Technical*: Token optimization — don't return the full table if only one cell is needed. Efficient re-rendering preserving alignments.
    * *Gap Analysis*: Missing `Table` struct, table parser, and `manage_table` tool implementation.
+   - [ ] *Critical Requirement*: `manage_table` must return a "Neighborhood" view (surrounding rows) rather than the full table to save tokens.
+   - [ ] *Critical Requirement*: Table struct must handle "Ragged Rows" (rows with mismatched column counts) gracefully during `Render`.
+   - [x] *Decision Resolved: Surgical Return*: `manage_table` returns a summary/neighborhood by default. Full table returned only if `show_table: true` is passed.
+   - [x] *Decision Resolved: Structural Validation*: Rows with mismatched column counts will be normalized (padded/truncated) during `Render` with a warning returned to the user.
 ** Data & Resource Mapping
    :PROPERTIES:
    :ID: 26174735

--- a/mcp/schema.go
+++ b/mcp/schema.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"reflect"
 	"slices"
 	"strconv"
@@ -9,6 +10,59 @@ import (
 
 type DefinedSchema interface {
 	GetSchema() map[string]any
+}
+
+type TaggedUnion interface {
+	Tag() string
+	Value() any
+	FromJSON([]byte) error
+}
+
+func Types[T TaggedUnion](t T) (types []reflect.Type) {
+	fields := reflect.VisibleFields(reflect.TypeOf(t).Elem())
+	for _, f := range fields {
+		if f.IsExported() {
+			types = append(types, f.Type)
+		}
+	}
+
+	return
+}
+
+type OneOf[T TaggedUnion] struct {
+	Value T
+}
+
+func NewOneOf[T TaggedUnion](value T) OneOf[T] {
+	return OneOf[T]{Value: value}
+}
+
+func (o OneOf[T]) GetSchema() map[string]any {
+	oneOfSchemas := make([]any, len(Types(o.Value)))
+
+	for i, option := range Types(o.Value) {
+		oneOfSchemas[i] = generateTypeSchema(option)
+	}
+
+	return map[string]any{
+		"oneOf": oneOfSchemas,
+	}
+}
+
+func (o *OneOf[T]) UnmarshalJSON(data []byte) error {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var t = reflect.New(reflect.TypeOf(o.Value).Elem()).Interface().(T)
+	err := t.FromJSON(data)
+
+	if err == nil {
+		o.Value = t
+	}
+
+	return err
 }
 
 // GenerateSchema takes a Go struct and returns a JSON Schema map suitable for MCP tool inputSchema.
@@ -21,7 +75,7 @@ func GenerateSchema(v any) map[string]any {
 	if t == nil {
 		return map[string]any{}
 	}
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -35,7 +89,7 @@ func generateTypeSchema(t reflect.Type) map[string]any {
 	}
 
 	// Handle pointers by getting the underlying type
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -91,6 +145,9 @@ func generateTypeSchema(t reflect.Type) map[string]any {
 						case "anyOf":
 							anyOfTypes := strings.Split(val, ";")
 							fieldSchema["anyOf"] = castAnyOfToType(anyOfTypes, field.Type)
+						case "oneOf":
+							oneOfTypes := strings.Split(val, ";")
+							fieldSchema["oneOf"] = castOneOfToType(oneOfTypes, field.Type)
 						}
 					}
 				}
@@ -183,6 +240,14 @@ func castSliceToType(vals []string, t reflect.Type) []any {
 }
 
 func castAnyOfToType(vals []string, _ reflect.Type) []any {
+	res := make([]any, len(vals))
+	for i, v := range vals {
+		res[i] = generateTypeSchema(reflect.TypeOf(v))
+	}
+	return res
+}
+
+func castOneOfToType(vals []string, _ reflect.Type) []any {
 	res := make([]any, len(vals))
 	for i, v := range vals {
 		res[i] = generateTypeSchema(reflect.TypeOf(v))

--- a/orgmcp/bullet.go
+++ b/orgmcp/bullet.go
@@ -309,6 +309,16 @@ func (b *Bullet) ParentUid() Uid {
 	}).UnwrapOr(NewUid(0))
 }
 
+func (b *Bullet) SetCheckbox(s BulletStatus) {
+	if s == NoCheck {
+		b.checkbox = NoCheck
+		b.prefix = Star
+	} else {
+		b.checkbox = s
+		b.prefix = Dash
+	}
+}
+
 // ToggleCheckbox toggles the checkbox state between Unchecked and Checked
 // Only works for bullets that already have a checkbox (not NoCheck)
 func (b *Bullet) ToggleCheckbox() {

--- a/orgmcp/file.go
+++ b/orgmcp/file.go
@@ -164,6 +164,10 @@ func ParseIndentedLine(r *reader.PeekReader, parent Render) option.Option[Render
 	}
 }
 
+func (of *OrgFile) Name() string {
+	return of.name
+}
+
 func (of *OrgFile) SetName(name string) {
 	of.name = name
 }

--- a/orgmcp/header.go
+++ b/orgmcp/header.go
@@ -227,6 +227,10 @@ func (h *Header) Schedule() option.Option[*Schedule] {
 	return option.Ref(&h.schedule)
 }
 
+func (h *Header) SetContent(c string) {
+	h.Content = c
+}
+
 func (h *Header) Render(builder *strings.Builder, depth int) {
 	builder.WriteString(strings.Repeat("*", h.Level()))
 	builder.WriteString(" ")

--- a/scripts/initialize_test.sh
+++ b/scripts/initialize_test.sh
@@ -4,4 +4,4 @@ go build .
 
 json='{ "method":"initialize", "params":{} }'
 
-echo "$json" | ./org-mcp
+echo "$json" | ./org-mcp serve

--- a/tools/bullet_tool.go
+++ b/tools/bullet_tool.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -13,34 +14,165 @@ import (
 )
 
 type BulletInput struct {
-	Bullets      []BulletValue    `json:"bullets,omitempty" jsonschema:"description=List of bullet point operations to perform."`
-	Path         string           `json:"path,omitempty" jsonschema:"description=Optional file path; defaults to ./.tasks.org."`
-	ShowDiff     bool             `json:"show_diff,omitempty" jsonschema:"description=Whether to show the diff of changes made to the Org file."`
-	ShowAffected *bool            `json:"show_affected,omitempty" jsonschema:"description=Whether to include the affected items in the response. This will include all items that were modified as well as their children.,default=true"`
-	Columns      []*orgmcp.Column `json:"columns,omitempty" jsonschema:"description=List of columns to include in the output. If not specified defaults to [UID | PREVIEW]."`
+	Bullets      []mcp.OneOf[*BulletInputUnion] `json:"bullets" jsonschema:"description=List of bullet point operations to perform."`
+	Path         string                         `json:"path,omitempty" jsonschema:"description=Optional file path; defaults to ./.tasks.org."`
+	ShowDiff     bool                           `json:"show_diff,omitempty" jsonschema:"description=Whether to show the diff of changes made to the Org file.,default=false"`
+	ShowAffected *bool                          `json:"show_affected,omitempty" jsonschema:"description=Whether to include the affected items in the response. This will include all items that were modified as well as their children.,default=true"`
+	Columns      []*orgmcp.Column               `json:"columns,omitempty" jsonschema:"description=List of columns to include in the output. If not specified defaults to [UID | PREVIEW]."`
 }
 
-type BulletValue struct {
-	Uid      string `json:"uid,omitempty" jsonschema:"description=UID of the bullet point to modify. For the 'add' method; this must be the parent header UID.,required=true"`
-	Method   string `json:"method" jsonschema:"description=The action to perform on the bullet point.,enum=add;remove;complete;toggle;set_content,required=true"`
-	Content  string `json:"content,omitempty" jsonschema:"description=Text content of the bullet."`
+type BulletInputUnion struct {
+	tag string
+
+	Add    BulletInputAdd
+	Update BulletInputUpdate
+	Remove BulletInputRemove
+}
+
+func (b *BulletInputUnion) Value() any {
+	switch b.tag {
+	case "add":
+		return b.Add
+	case "update":
+		return b.Update
+	case "remove":
+		return b.Remove
+	default:
+		return nil
+	}
+}
+
+func (b *BulletInputUnion) Tag() string {
+	return b.tag
+}
+
+func (b *BulletInputUnion) FromJSON(data []byte) error {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	switch raw["method"] {
+	case "add":
+		b.tag = "add"
+		return json.Unmarshal(data, &b.Add)
+	case "update":
+		b.tag = "update"
+		return json.Unmarshal(data, &b.Update)
+	case "remove":
+		b.tag = "remove"
+		return json.Unmarshal(data, &b.Remove)
+	default:
+		return errors.New("invalid method; must be 'add', 'update' or 'remove'")
+	}
+}
+
+type BulletInputAdd struct {
+	Method   string `json:"method" jsonschema:"description=The action to perform on the bullet point.,enum=add,required=true"`
+	Parent   string `json:"parent" jsonschema:"description=UID of the parent header or bullet under which to add the new bullet point."`
+	Content  string `json:"content" jsonschema:"description=Text content of the new bullet point."`
 	Checkbox string `json:"checkbox,omitempty" jsonschema:"description=Checkbox status for the new bullet.,enum=None;Unchecked;Checked"`
+}
+
+func (b *BulletInputAdd) Apply(ctx context.Context, of *orgmcp.OrgFile) (res ApplyResult) {
+	res.affectedItems = make(map[orgmcp.Uid]orgmcp.Render)
+
+	parent, ok := of.GetUid(orgmcp.NewUid(b.Parent)).Split()
+	if !ok {
+		res.err = fmt.Errorf("Parent uid %s not found, skipping addition.", b.Parent)
+		return
+	}
+
+	bullet := orgmcp.NewBullet(parent, orgmcp.NewBulletStatus(b.Checkbox))
+	bullet.SetContent(b.Content)
+
+	res.affectedItems[bullet.Uid()] = bullet
+
+	return
+}
+
+type BulletInputUpdate struct {
+	Method   string `json:"method" jsonschema:"description=The action to perform on the bullet point.,enum=update,required=true"`
+	Uid      string `json:"uid" jsonschema:"description=UID of the bullet point to modify.,required=true"`
+	Content  string `json:"content,omitempty" jsonschema:"description=Text content of the bullet."`
+	Checkbox string `json:"checkbox,omitempty" jsonschema:"description=Checkbox status for the bullet.,enum=None;Unchecked;Checked"`
+}
+
+func (b *BulletInputUpdate) Apply(ctx context.Context, of *orgmcp.OrgFile) (res ApplyResult) {
+	res.affectedItems = make(map[orgmcp.Uid]orgmcp.Render)
+
+	selected, ok := of.GetUid(orgmcp.NewUid(b.Uid)).Split()
+	if !ok {
+		res.err = fmt.Errorf("Uid %s not found", b.Uid)
+		return
+	}
+
+	bullet, ok := selected.(*orgmcp.Bullet)
+	if !ok {
+		res.err = fmt.Errorf("UID %s does not correspond to a bullet, skipping update.", b.Uid)
+		return
+	}
+
+	if b.Content != "" {
+		bullet.SetContent(b.Content)
+	}
+
+	if b.Checkbox != "" {
+		switch b.Checkbox {
+		case "None":
+			bullet.SetCheckbox(orgmcp.NoCheck)
+		case "Unchecked":
+			bullet.SetCheckbox(orgmcp.Unchecked)
+		case "Checked":
+			bullet.SetCheckbox(orgmcp.Checked)
+		default:
+			res.err = fmt.Errorf("invalid checkbox value: %s", b.Checkbox)
+			return
+		}
+	}
+
+	res.affectedItems[bullet.Uid()] = bullet
+
+	return
+}
+
+type BulletInputRemove struct {
+	Method string `json:"method" jsonschema:"description=The action to perform on the bullet point.,enum=remove,required=true"`
+	Uid    string `json:"uid" jsonschema:"description=UID of the bullet point to remove."`
+}
+
+func (b *BulletInputRemove) Apply(ctx context.Context, of *orgmcp.OrgFile) (res ApplyResult) {
+	res.affectedItems = make(map[orgmcp.Uid]orgmcp.Render)
+
+	selected, ok := of.GetUid(orgmcp.NewUid(b.Uid)).Split()
+	if !ok {
+		res.err = fmt.Errorf("Uid %s not found", b.Uid)
+		return
+	}
+
+	header, ok := of.GetUid(selected.ParentUid()).Split()
+	if !ok {
+		res.err = fmt.Errorf("Parent header for bullet with UID %s not found, skipping removal.", b.Uid)
+		return
+	}
+
+	header.RemoveChildren(orgmcp.NewUid(b.Uid))
+
+	res.affectedItems[header.Uid()] = header
+
+	return
 }
 
 var BulletTool = mcp.GenericTool[BulletInput]{
 	Name: "manage_bullet",
 	Description: "Add, remove or complete bullet points.\n" +
-		"The method parameter defines the action to take: 'add', 'remove', 'complete', 'toggle' or 'set_content'.\n" +
+		"The method parameter defines the action to take: 'add', 'remove' or 'update'.\n" +
 		"- 'add': Adds a new bullet point at the specified index under the given header_uid. Requires 'content' and 'checkbox' parameters.\n" +
 		"- 'remove': Removes the bullet point identified by its uid.\n" +
-		"- 'complete': Marks the bullet point as completed (Checked).\n" +
-		"- 'toggle': Toggles the checkbox status of the bullet point between Checked and Unchecked.\n" +
-		"- 'set_content': Updates the content of the bullet point. Requires 'content' parameter.\n\n" +
-		"The 'header_uid' parameter specifies the parent header under which the bullet point resides.\n" +
-		"The 'bullet_index' parameter specifies the position of the bullet point under the header (0-based index).\n\n" +
+		"- 'update': Updates the content of the bullet point. Requires 'content' parameter.\n\n" +
 		"When targeting a bullet, the uid is constructed as `header_uid + '.b' + bullet_index`.\n" +
-		"Bullets are hierarchical meaning that bullets can have sub-bullets. Sub-bullets will use parent_bullet_uid + '.b' + bullet_sub_index like header_uid.b0.b1\n" +
-		"The add method is special as it requires the header_uid to be passed directly without any bullet index. The index will be determined by the tool itself.",
+		"The 'bullet_index' specifies the position of the bullet point under the header (0-based index).\n\n" +
+		"Bullets are hierarchical meaning that bullets can have sub-bullets. Sub-bullets will use parent_bullet_uid + '.b' + bullet_sub_index like header_uid.b0.b1\n",
 	Callback: bulletFunc,
 }
 
@@ -61,104 +193,24 @@ func bulletFunc(ctx context.Context, input BulletInput, options mcp.FuncOptions)
 	affectedCount := 0
 	affectedItems := map[orgmcp.Uid]orgmcp.Render{}
 
-	for _, b := range input.Bullets {
-		selected, ok := orgFile.GetUid(orgmcp.NewUid(b.Uid)).Split()
-		if !ok {
-			resp = append(resp, fmt.Sprintf("Uid %s not found in %s", b.Uid, path))
-			continue
-		}
+	for _, mt := range input.Bullets {
+		var res ApplyResult
 
-		switch b.Method {
+		switch mt.Value.Tag() {
 		case "add":
-			currentProgress := selected.CheckProgress()
-
-			bullet := orgmcp.NewBullet(selected, orgmcp.NewBulletStatus(b.Checkbox))
-			bullet.SetContent(b.Content)
-
-			if selected.CheckProgress().AndThen(func(p orgmcp.Progress) bool {
-				return currentProgress.IsSome() && p.Equal(currentProgress.Unwrap())
-			}) {
-				affectedCount += 1
-			}
+			res = mt.Value.Add.Apply(ctx, &orgFile)
+		case "update":
+			res = mt.Value.Update.Apply(ctx, &orgFile)
 		case "remove":
-			header, ok := orgFile.GetUid(selected.ParentUid()).Split()
-			if !ok {
-				resp = append(resp, fmt.Sprintf("Parent header for bullet with UID %s not found in %s, skipping removal.", b.Uid, path))
-				continue
-			}
-
-			currentProgress := header.CheckProgress()
-
-			header.RemoveChildren(orgmcp.NewUid(b.Uid))
-			header.CheckProgress()
-
-			if header.CheckProgress().AndThen(func(p orgmcp.Progress) bool {
-				return currentProgress.IsSome() && p.Equal(currentProgress.Unwrap())
-			}) {
-				affectedCount += 1
-			}
-		case "complete":
-			bullet, ok := selected.(*orgmcp.Bullet)
-			if !ok {
-				resp = append(resp, fmt.Sprintf("UID %s does not correspond to a bullet in %s, skipping completion.", b.Uid, path))
-				continue
-			}
-
-			header, ok := orgFile.GetUid(bullet.Uid()).Split()
-			if !ok {
-				resp = append(resp, fmt.Sprintf("Parent header for bullet with UID %s not found in %s, skipping completion.", b.Uid, path))
-				continue
-			}
-
-			currentProgress := header.CheckProgress()
-			bullet.CompleteCheckbox()
-
-			if header.CheckProgress().AndThen(func(p orgmcp.Progress) bool {
-				return currentProgress.IsSome() && p.Equal(currentProgress.Unwrap())
-			}) {
-				affectedCount += 1
-			}
-		case "toggle":
-			bullet, ok := selected.(*orgmcp.Bullet)
-			if !ok {
-				resp = append(resp, fmt.Sprintf("UID %s does not correspond to a bullet in %s, skipping toggle.", b.Uid, path))
-				continue
-			}
-
-			header, ok := orgFile.GetUid(bullet.Uid()).Split()
-			if !ok {
-				resp = append(resp, fmt.Sprintf("Parent header for bullet with UID %s not found in %s, skipping completion.", b.Uid, path))
-				continue
-			}
-
-			currentProgress := header.CheckProgress()
-			bullet.ToggleCheckbox()
-
-			if header.CheckProgress().AndThen(func(p orgmcp.Progress) bool {
-				return currentProgress.IsSome() && p.Equal(currentProgress.Unwrap())
-			}) {
-				affectedCount += 1
-			}
-		case "set_content":
-			bullet, ok := selected.(*orgmcp.Bullet)
-			if !ok {
-				resp = append(resp, fmt.Sprintf("UID %s does not correspond to a bullet in %s, skipping content update.", b.Uid, path))
-				continue
-			}
-
-			bullet.SetContent(b.Content)
-			affectedItems[bullet.Uid()] = bullet
-			affectedCount += 1
-		default:
-			return nil, errors.New("invalid method; must be 'add', 'remove', 'complete', 'toggle' or 'set_content'")
+			res = mt.Value.Remove.Apply(ctx, &orgFile)
 		}
 
-		affectedItems[selected.Uid()] = selected
-		for _, child := range selected.ChildrenRec(1) {
-			affectedItems[child.Uid()] = child
+		if res.err != nil {
+			resp = append(resp, res.err)
 		}
 
-		affectedCount += 1
+		maps.Copy(affectedItems, res.affectedItems)
+		affectedCount += len(res.affectedItems)
 	}
 
 	ordered := []orgmcp.Render{}
@@ -166,18 +218,18 @@ func bulletFunc(ctx context.Context, input BulletInput, options mcp.FuncOptions)
 	if input.ShowAffected == nil || *input.ShowAffected == true {
 		locationTable := orgFile.BuildLocationTable()
 		ordered = append(ordered, itertools.Collect(maps.Values(affectedItems))...)
+
 		slices.SortFunc(ordered, func(a, b orgmcp.Render) int {
 			return (*locationTable)[a.Uid()] - (*locationTable)[b.Uid()]
 		})
-		resp = append(resp, orgmcp.PrintCsv(ordered, input.Columns))
 
+		resp = append(resp, orgmcp.PrintCsv(ordered, input.Columns))
 		resp = append(resp, map[string]any{
 			"affected_count": affectedCount,
 		})
 	}
 
 	diff, err := mcp.WriteOrgFileToDisk(ctx, orgFile, path)
-
 	if input.ShowDiff {
 		resp = append(resp, diff)
 	}

--- a/tools/header_tool.go
+++ b/tools/header_tool.go
@@ -2,29 +2,197 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"maps"
 	"slices"
 
 	"github.com/p3rtang/org-mcp/mcp"
 	"github.com/p3rtang/org-mcp/orgmcp"
+	"github.com/p3rtang/org-mcp/utils/itertools"
 	"github.com/p3rtang/org-mcp/utils/option"
 )
 
 type HeaderInput struct {
-	Headers  []HeaderValue    `json:"headers" jsonschema:"description=List of header operations to perform. Multiple operations can be performed in a single call."`
-	Path     string           `json:"path,omitempty" jsonschema:"description=The file path to the Org file to modify. It will target the ./.tasks.org by default and you don't have to pass this in unless you want to target a different file.,required=false"`
-	ShowDiff bool             `json:"show_diff,omitempty" jsonschema:"description=Whether to return the diff of changes made to the file. Can be used to inform the user of what changed.,required=false"`
-	Columns  []*orgmcp.Column `json:"columns,omitempty" jsonschema:"description=List of columns to include in the output. If not specified defaults to [UID | PREVIEW]."`
+	Headers      []mcp.OneOf[*HeaderInputUnion] `json:"headers" jsonschema:"description=List of header operations to perform. Multiple operations can be performed in a single call."`
+	Path         string                         `json:"path,omitempty" jsonschema:"description=The file path to the Org file to modify. It will target the ./.tasks.org by default and you don't have to pass this in unless you want to target a different file.,required=false"`
+	ShowDiff     bool                           `json:"show_diff,omitempty" jsonschema:"description=Whether to return the diff of changes made to the file. Can be used to inform the user of what changed.,required=false"`
+	ShowAffected *bool                          `json:"show_affected,omitempty" jsonschema:"description=Whether to include the affected items in the response. This will include all items that were modified as well as their children.,default=true,required=false"`
+	Columns      []*orgmcp.Column               `json:"columns,omitempty" jsonschema:"description=List of columns to include in the output. If not specified defaults to [UID | PREVIEW]."`
 }
 
-type HeaderValue struct {
-	Uid     string   `json:"uid" jsonschema:"description=UID of the header to modify or the parent_uid when adding."`
-	Method  string   `json:"method" jsonschema:"description=The method by which to manage the header.;enum=add;remove;update"`
-	Status  string   `json:"status" jsonschema:"description=The new status of the header (e.g. TODO; DONE). Required for 'update' and 'add' method. Use 'NONE' to clear status. An empty string will leave the status unchanged during 'update'.;enum=TODO;NEXT;PROG;REVW;DONE;DELG;NONE"`
-	Content string   `json:"content,omitempty" jsonschema:"description=The content of the header. Required for 'add' and optional for 'update' method."`
-	Tags    []string `json:"tags,omitempty" jsonschema:"description=List of tags to set for the header. Optional for 'update' and 'add' method. Both an empty list and omitting this field will leave tags unchanged during 'update'."`
-	Depth   *int     `json:"depth,omitempty" jsonschema:"description=The depth to return children headers. 0 means no children; 1 means direct children only and so on. If omitted defaults to 1."`
+type HeaderInputUnion struct {
+	tag string
+
+	Add    HeaderInputAdd
+	Update HeaderInputUpdate
+	Remove HeaderInputRemove
+}
+
+func NewHeaderInputUnion[T HeaderInputAdd | HeaderInputUpdate | HeaderInputRemove](input T) *HeaderInputUnion {
+	switch any(input).(type) {
+	case HeaderInputAdd:
+		return &HeaderInputUnion{
+			tag: "add",
+			Add: any(input).(HeaderInputAdd),
+		}
+	case HeaderInputUpdate:
+		return &HeaderInputUnion{
+			tag:    "update",
+			Update: any(input).(HeaderInputUpdate),
+		}
+	case HeaderInputRemove:
+		return &HeaderInputUnion{
+			tag:    "remove",
+			Remove: any(input).(HeaderInputRemove),
+		}
+	default:
+		panic(fmt.Sprintf("unsupported type for HeaderInputUnion: %s", fmt.Sprintf("%T", input)))
+	}
+}
+
+func (u HeaderInputUnion) Tag() string {
+	return u.tag
+}
+
+func (u HeaderInputUnion) Value() any {
+	switch u.tag {
+	case "add":
+		return u.Add
+	case "update":
+		return u.Update
+	case "remove":
+		return u.Remove
+	default:
+		return nil
+	}
+}
+
+func (u *HeaderInputUnion) FromJSON(data []byte) error {
+	var temp struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	switch temp.Method {
+	case "add":
+		u.tag = "add"
+		return json.Unmarshal(data, &u.Add)
+	case "update":
+		u.tag = "update"
+		return json.Unmarshal(data, &u.Update)
+	case "remove":
+		u.tag = "remove"
+		return json.Unmarshal(data, &u.Remove)
+	default:
+		return errors.New("invalid method for header operation")
+	}
+}
+
+type HeaderInputAdd struct {
+	Method  string   `json:"method" jsonschema:"description=Add a new header.,enum=add"`
+	Parent  string   `json:"parent" jsonschema:"description=UID of the parent header under which to add the new header."`
+	Content string   `json:"content" jsonschema:"description=The content of the new header."`
+	Status  string   `json:"status,omitempty" jsonschema:"description=The status of the new header (e.g. TODO; DONE). Use 'NONE' or omit the field to leave status empty.,enum=TODO;NEXT;PROG;REVW;DONE;DELG;NONE"`
+	Tags    []string `json:"tags,omitempty" jsonschema:"description=List of tags to set for the new header. An empty list or omitting this field will leave tags empty."`
+}
+
+func (h HeaderInputAdd) Apply(ctx context.Context, of *orgmcp.OrgFile) (res ApplyResult) {
+	res.affectedItems = make(map[orgmcp.Uid]orgmcp.Render)
+
+	if h.Content == "" {
+		res.err = errors.New("Content cannot be empty when adding a header.")
+		return
+	}
+
+	parent, ok := of.GetUid(orgmcp.NewUid(h.Parent)).Split()
+	if !ok {
+		res.err = fmt.Errorf("Parent UID %s not found.", h.Parent)
+		return
+	}
+
+	header := orgmcp.NewHeader(
+		orgmcp.HeaderStatus(h.Status),
+		h.Content,
+	)
+
+	if len(h.Tags) != 0 {
+		header.Tags = option.Some(orgmcp.TagList(h.Tags))
+	}
+
+	parent.AddChildren(&header)
+
+	res.affectedItems[parent.Uid()] = &header
+
+	return
+}
+
+type HeaderInputUpdate struct {
+	Method  string   `json:"method" jsonschema:"description=Update an existing header.,enum=update"`
+	Uid     string   `json:"uid" jsonschema:"description=UID of the header to update."`
+	Content string   `json:"content,omitempty" jsonschema:"description=The new content of the header. Omit this field to keep the content unchanged."`
+	Status  string   `json:"status,omitempty" jsonschema:"description=The new status of the header (e.g. TODO; DONE). Use 'NONE' to clear status. An empty string or omitting this field will leave status unchanged.,enum=TODO;NEXT;PROG;REVW;DONE;DELG;NONE"`
+	Tags    []string `json:"tags,omitempty" jsonschema:"description=List of tags to set for the header. Both an empty list and omitting this field will leave tags unchanged."`
+}
+
+func (h HeaderInputUpdate) Apply(ctx context.Context, of *orgmcp.OrgFile) (res ApplyResult) {
+	res.affectedItems = make(map[orgmcp.Uid]orgmcp.Render)
+
+	header, ok := option.Cast[orgmcp.Render, *orgmcp.Header](of.GetUid(orgmcp.NewUid(h.Uid))).Split()
+	if !ok {
+		res.err = fmt.Errorf("Header with UID %s not found.", h.Uid)
+		return
+	}
+
+	if h.Content != "" {
+		header.SetContent(h.Content)
+	}
+
+	if h.Status != "" {
+		header.SetStatus(orgmcp.HeaderStatus(h.Status))
+	}
+
+	if len(h.Tags) != 0 {
+		header.Tags = option.Some(orgmcp.TagList(h.Tags))
+	}
+
+	res.affectedItems[header.Uid()] = header
+
+	return
+}
+
+type HeaderInputRemove struct {
+	Method string `json:"method" jsonschema:"description=Remove an existing header.,enum=remove"`
+	Uid    string `json:"uid" jsonschema:"description=UID of the header to remove."`
+}
+
+func (h HeaderInputRemove) Apply(ctx context.Context, of *orgmcp.OrgFile) (res ApplyResult) {
+	res.affectedItems = make(map[orgmcp.Uid]orgmcp.Render)
+
+	header, ok := of.GetUid(orgmcp.NewUid(h.Uid)).Split()
+	if !ok {
+		res.err = fmt.Errorf("Header with UID %s not found.", h.Uid)
+		return
+	}
+
+	parent, ok := of.GetUid(header.ParentUid()).Split()
+	if !ok {
+		res.err = fmt.Errorf("Parent of header with UID %s not found.", h.Uid)
+		return
+	}
+
+	err := parent.RemoveChildren(header.Uid())
+	if err != nil {
+		res.err = err
+		return
+	}
+
+	res.affectedItems[parent.Uid()] = parent
+
+	return
 }
 
 var HeaderTool = mcp.GenericTool[HeaderInput]{
@@ -38,7 +206,6 @@ var HeaderTool = mcp.GenericTool[HeaderInput]{
 		"It is recommended to pass uid's as string to the function. While they will almost certainly be numbers; this is not guaranteed.",
 	Callback: func(ctx context.Context, input HeaderInput, options mcp.FuncOptions) (resp []any, err error) {
 		var path string
-
 		if input.Path == "" {
 			path = options.DefaultPath
 		} else {
@@ -50,128 +217,46 @@ var HeaderTool = mcp.GenericTool[HeaderInput]{
 			return
 		}
 
-		if len(input.Columns) == 0 {
-			uidCol := orgmcp.ColUid
-			contentCol := orgmcp.ColContent
-			input.Columns = []*orgmcp.Column{&uidCol, &contentCol}
-		}
+		affectedCount := 0
+		affectedItems := map[orgmcp.Uid]orgmcp.Render{}
 
-		var ordered []orgmcp.Render
-		results := map[orgmcp.Uid]orgmcp.Render{}
+		for _, mt := range input.Headers {
+			var res ApplyResult
 
-		for _, headerOp := range input.Headers {
-			switch headerOp.Method {
+			switch mt.Value.Tag() {
 			case "add":
-				parent, ok := orgFile.GetUid(orgmcp.NewUid(headerOp.Uid)).Split()
-				if !ok {
-					err = errors.New("invalid parent UID for adding header")
-					return
-				}
-
-				var tags option.Option[orgmcp.TagList]
-				if len(headerOp.Tags) == 0 {
-					tags = option.None[orgmcp.TagList]()
-				} else {
-					tags = option.Some(orgmcp.TagList(headerOp.Tags))
-				}
-
-				newHeader := orgmcp.NewHeader(
-					orgmcp.HeaderStatus(headerOp.Status),
-					headerOp.Content,
-				)
-
-				newHeader.Tags = tags
-				newHeader.SetLevel(parent.Level() + 1)
-
-				parent.AddChildren(&newHeader)
-
-				depth := 1
-				if headerOp.Depth != nil {
-					depth = *headerOp.Depth
-				}
-
-				results[newHeader.Uid()] = &newHeader
-
-				for _, child := range newHeader.ChildrenRec(depth) {
-					results[child.Uid()] = child
-				}
-			case "remove":
-				header, ok := orgFile.GetUid(orgmcp.NewUid(headerOp.Uid)).Split()
-				if !ok {
-					err = errors.New("invalid header UID for removal")
-					return
-				}
-
-				parent, ok := orgFile.GetUid(header.ParentUid()).Split()
-				if !ok {
-					err = errors.New("Missing or invalid parent for header removal")
-					return
-				}
-
-				err = parent.RemoveChildren(orgmcp.NewUid(headerOp.Uid))
-
-				if err != nil {
-					return
-				}
-
-				depth := 1
-				if headerOp.Depth != nil {
-					depth = *headerOp.Depth
-				}
-
-				results[header.Uid()] = header
-
-				for _, child := range header.ChildrenRec(depth) {
-					results[child.Uid()] = child
-				}
+				res = mt.Value.Add.Apply(ctx, &orgFile)
 			case "update":
-				header, ok := option.Cast[orgmcp.Render, *orgmcp.Header](orgFile.GetUid(orgmcp.NewUid(headerOp.Uid))).Split()
-				if !ok {
-					err = errors.New("invalid header UID for update or not a header")
-					return
-				}
-
-				if headerOp.Content != "" {
-					header.Content = headerOp.Content
-				}
-
-				if headerOp.Status != "" {
-					header.SetStatus(orgmcp.StatusFromString(headerOp.Status))
-				}
-
-				if len(headerOp.Tags) != 0 {
-					tags := option.Some(orgmcp.TagList(headerOp.Tags))
-					header.Tags = tags
-				}
-
-				depth := 1
-				if headerOp.Depth != nil {
-					depth = *headerOp.Depth
-				}
-
-				results[header.Uid()] = header
-
-				for _, child := range header.ChildrenRec(depth) {
-					results[child.Uid()] = child
-				}
-			default:
-				err = errors.New("invalid method for header management")
+				res = mt.Value.Update.Apply(ctx, &orgFile)
+			case "remove":
+				res = mt.Value.Remove.Apply(ctx, &orgFile)
 			}
 
-			if err != nil {
-				return
+			if res.err != nil {
+				resp = append(resp, res.err.Error())
 			}
+
+			maps.Copy(affectedItems, res.affectedItems)
+			affectedCount += len(res.affectedItems)
 		}
 
-		locationTable := orgFile.BuildLocationTable()
-		ordered = append(ordered, slices.Collect(maps.Values(results))...)
-		slices.SortFunc(ordered, func(a, b orgmcp.Render) int {
-			return (*locationTable)[a.Uid()] - (*locationTable)[b.Uid()]
-		})
-		resp = append(resp, orgmcp.PrintCsv(ordered, input.Columns))
+		ordered := []orgmcp.Render{}
+
+		if input.ShowAffected == nil || *input.ShowAffected == true {
+			locationTable := orgFile.BuildLocationTable()
+			ordered = append(ordered, itertools.Collect(maps.Values(affectedItems))...)
+
+			slices.SortFunc(ordered, func(a, b orgmcp.Render) int {
+				return (*locationTable)[a.Uid()] - (*locationTable)[b.Uid()]
+			})
+
+			resp = append(resp, orgmcp.PrintCsv(ordered, input.Columns))
+			resp = append(resp, map[string]any{
+				"affected_count": affectedCount,
+			})
+		}
 
 		diff, err := mcp.WriteOrgFileToDisk(ctx, orgFile, path)
-
 		if input.ShowDiff {
 			resp = append(resp, diff)
 		}

--- a/tools/test/auto_closed_test.go
+++ b/tools/test/auto_closed_test.go
@@ -21,15 +21,24 @@ func TestAutoClosed(t *testing.T) {
 	revwUid := NewTestHeader(&of)
 	todoUid := NewTestHeader(&of)
 
+	showAffected := true
+
 	mcp.WriteOrgFileToDisk(context.TODO(), of, "./test.org")
 
 	tests := []ManageHeaderTest{
 		{
 			name: "DoneAutoClose",
 			input: tools.HeaderInput{
-				Headers: []tools.HeaderValue{
-					{Uid: doneUid.String(), Status: "DONE", Method: "update"},
+				Headers: []mcp.OneOf[*tools.HeaderInputUnion]{
+					{
+						Value: tools.NewHeaderInputUnion(tools.HeaderInputUpdate{
+							Uid:    doneUid.String(),
+							Status: "DONE",
+							Method: "update",
+						}),
+					},
 				},
+				ShowAffected: &showAffected,
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue, &orgmcp.ColStatusValue, &orgmcp.ColClosedValue,
 				},
@@ -39,9 +48,16 @@ func TestAutoClosed(t *testing.T) {
 		{
 			name: "ReviewAutoClose",
 			input: tools.HeaderInput{
-				Headers: []tools.HeaderValue{
-					{Uid: revwUid.String(), Status: "REVW", Method: "update"},
+				Headers: []mcp.OneOf[*tools.HeaderInputUnion]{
+					{
+						Value: tools.NewHeaderInputUnion(tools.HeaderInputUpdate{
+							Uid:    revwUid.String(),
+							Status: "REVW",
+							Method: "update",
+						}),
+					},
 				},
+				ShowAffected: &showAffected,
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue, &orgmcp.ColStatusValue, &orgmcp.ColClosedValue,
 				},
@@ -51,9 +67,16 @@ func TestAutoClosed(t *testing.T) {
 		{
 			name: "NoAutoClose",
 			input: tools.HeaderInput{
-				Headers: []tools.HeaderValue{
-					{Uid: todoUid.String(), Status: "TODO", Method: "update"},
+				Headers: []mcp.OneOf[*tools.HeaderInputUnion]{
+					{
+						Value: tools.NewHeaderInputUnion(tools.HeaderInputUpdate{
+							Uid:    todoUid.String(),
+							Status: "TODO",
+							Method: "update",
+						}),
+					},
 				},
+				ShowAffected: &showAffected,
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue, &orgmcp.ColStatusValue, &orgmcp.ColClosedValue,
 				},

--- a/tools/test/text_tool_test.go
+++ b/tools/test/text_tool_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/p3rtang/org-mcp/tools"
 )
 
+func IntoOneOfArray[T tools.TextInputAdd | tools.TextInputUpdate | tools.TextInputRemove](t ...T) []mcp.OneOf[*tools.TextInputUnion] {
+	entries := []mcp.OneOf[*tools.TextInputUnion]{}
+
+	for _, input := range t {
+		entries = append(entries, mcp.OneOf[*tools.TextInputUnion]{
+			Value: tools.NewTextInputUnion(input),
+		})
+	}
+
+	return entries
+}
+
 func TestTextTool(t *testing.T) {
 	showDebug := os.Getenv("SHOW_DEBUG")
 	if showDebug == "" {
@@ -40,13 +52,11 @@ func TestTextTool(t *testing.T) {
 		{
 			name: "AddTextToHeader",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     addHeaderUid,
-						Method:  "add",
-						Content: "Added text content",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputAdd{
+					Parent:  addHeaderUid,
+					Method:  "add",
+					Content: "Added text content",
+				}),
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
 					&orgmcp.ColPreviewValue,
@@ -57,13 +67,11 @@ func TestTextTool(t *testing.T) {
 		{
 			name: "UpdateTextContent",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     plainTextUid,
-						Method:  "update",
-						Content: "Updated text content",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputUpdate{
+					Uid:     plainTextUid,
+					Method:  "update",
+					Content: "Updated text content",
+				}),
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
 					&orgmcp.ColPreviewValue,
@@ -74,13 +82,11 @@ func TestTextTool(t *testing.T) {
 		{
 			name: "AddTextWithMultipleColumns",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     addHeaderUid,
-						Method:  "add",
-						Content: "Additional text",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputAdd{
+					Parent:  addHeaderUid,
+					Method:  "add",
+					Content: "Additional text",
+				}),
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
 					&orgmcp.ColContentValue,
@@ -91,13 +97,11 @@ func TestTextTool(t *testing.T) {
 		{
 			name: "ShowDiff",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     plainTextUid,
-						Method:  "update",
-						Content: "Content with diff",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputUpdate{
+					Uid:     plainTextUid,
+					Method:  "update",
+					Content: "Content with diff",
+				}),
 				ShowDiff: true,
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
@@ -108,55 +112,49 @@ func TestTextTool(t *testing.T) {
 		{
 			name: "InvalidUid",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:    "invalid-uid-12345",
-						Method: "add",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputAdd{
+					Parent:  "invalid-uid-12345",
+					Method:  "add",
+					Content: "This should fail",
+				}),
 			},
-			expected: []any{"Uid invalid-uid-12345 not found"},
+			expected: []any{"Parent uid invalid-uid-12345 not found."},
 		},
 		{
 			name: "UpdateNonPlainTextFails",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     updateHeaderUid,
-						Method:  "update",
-						Content: "This should fail",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputUpdate{
+					Uid:     updateHeaderUid,
+					Method:  "update",
+					Content: "This should fail",
+				}),
 			},
 			expected: []any{"is not a plain text element, cannot update content"},
 		},
-		{
-			name: "NewlinesReplacedWithSpaces",
-			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     addHeaderUid,
-						Method:  "add",
-						Content: "Text with\nnewlines",
-					},
-				},
-				Columns: []*orgmcp.Column{
-					&orgmcp.ColUidValue,
-					&orgmcp.ColContentValue,
-				},
-			},
-			expected: []any{"newlines will be replaced with spaces"},
-		},
+		// TODO: this should test multiple entries are added now
+		// {
+		// 	name: "NewlinesReplacedWithSpaces",
+		// 	input: tools.TextInputSchema{
+		// 		Texts: IntoOneOfArray(tools.TextInputAdd{
+		// 			Parent:     addHeaderUid,
+		// 			Method:  "add",
+		// 			Content: "Text with\nnewlines",
+		// 		}),
+		// 		Columns: []*orgmcp.Column{
+		// 			&orgmcp.ColUidValue,
+		// 			&orgmcp.ColContentValue,
+		// 		},
+		// 	},
+		// 	expected: []any{"newlines will be replaced with spaces"},
+		// },
 		{
 			name: "ShowAffectedFalse",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     addHeaderUid,
-						Method:  "add",
-						Content: "Test content",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputAdd{
+					Parent:  addHeaderUid,
+					Method:  "add",
+					Content: "Test content",
+				}),
 				ShowAffected: func() *bool { b := false; return &b }(),
 			},
 			expectEmpty: true,
@@ -164,38 +162,35 @@ func TestTextTool(t *testing.T) {
 		{
 			name: "RemoveTextContent",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:    plainTextUid,
-						Method: "remove",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputRemove{
+					Uid:    plainTextUid,
+					Method: "remove",
+				}),
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
 				},
 			},
-			expected: []any{"99998889.t0"},
+			expected: []any{"99998889"},
 		},
 		{
 			name: "AddMultipleTextsToSameHeader",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     addHeaderUid,
-						Method:  "add",
-						Content: "First addition",
-					},
-					{
-						Uid:     addHeaderUid,
+				Texts: IntoOneOfArray(tools.TextInputAdd{
+					Parent:  addHeaderUid,
+					Method:  "add",
+					Content: "First addition",
+				},
+					tools.TextInputAdd{
+						Parent:  addHeaderUid,
 						Method:  "add",
 						Content: "Second addition",
 					},
-					{
-						Uid:     addHeaderUid,
+					tools.TextInputAdd{
+						Parent:  addHeaderUid,
 						Method:  "add",
 						Content: "Third addition",
 					},
-				},
+				),
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
 					&orgmcp.ColPreviewValue,
@@ -206,26 +201,22 @@ func TestTextTool(t *testing.T) {
 		{
 			name: "RemoveNonExistentTextFails",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:    "99998889.t999",
-						Method: "remove",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputRemove{
+					Uid:    "99998889.t999",
+					Method: "remove",
+				}),
 			},
-			expected: []any{"Uid 99998889.t999 not found in ./test.org"},
+			expected: []any{"Item with uid 99998889.t999 not found in ./test.org."},
 		},
 		{
 			// Plain text CAN be added as a child of a bullet
 			name: "AddPlainTextToBullet",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     bulletWithChildrenUid,
-						Method:  "add",
-						Content: "Text under a bullet",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputAdd{
+					Parent:  bulletWithChildrenUid,
+					Method:  "add",
+					Content: "Text under a bullet",
+				}),
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
 					&orgmcp.ColPreviewValue,
@@ -238,13 +229,11 @@ func TestTextTool(t *testing.T) {
 			// Update plain text that exists under a bullet in test.org
 			name: "UpdatePlainTextUnderBullet",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     "99998891.b0.t0",
-						Method:  "update",
-						Content: "Updated plain text under bullet",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputUpdate{
+					Uid:     "99998891.b0.t0",
+					Method:  "update",
+					Content: "Updated plain text under bullet",
+				}),
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
 					&orgmcp.ColPreviewValue,
@@ -256,13 +245,11 @@ func TestTextTool(t *testing.T) {
 		{
 			name: "AddTextToHeaderWithBullet",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     "3",
-						Method:  "add",
-						Content: "Text under header with bullets",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputAdd{
+					Parent:  "3",
+					Method:  "add",
+					Content: "Text under header with bullets",
+				}),
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
 					&orgmcp.ColPreviewValue,
@@ -273,13 +260,11 @@ func TestTextTool(t *testing.T) {
 		{
 			name: "HeaderCorruptionRepro",
 			input: tools.TextInputSchema{
-				Texts: []tools.TextInputValue{
-					{
-						Uid:     "99998892.t0",
-						Method:  "update",
-						Content: "Updated text content.",
-					},
-				},
+				Texts: IntoOneOfArray(tools.TextInputUpdate{
+					Uid:     "99998892.t0",
+					Method:  "update",
+					Content: "Updated text content.",
+				}),
 				Columns: []*orgmcp.Column{
 					&orgmcp.ColUidValue,
 					&orgmcp.ColPreviewValue,

--- a/tools/text_tool.go
+++ b/tools/text_tool.go
@@ -2,8 +2,10 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -13,17 +15,172 @@ import (
 )
 
 type TextInputSchema struct {
-	Texts        []TextInputValue `json:"texts" jsonschema:"description=The list of text modifications to perform"`
-	Path         string           `json:"path,omitempty" jsonschema:"description=The path to the Org file to modify; if not provided it will default to the current workspace file,required=false"`
-	ShowDiff     bool             `json:"show_diff,omitempty" jsonschema:"description=Whether to show a diff of the changes made; default is false,required=false"`
-	ShowAffected *bool            `json:"show_affected,omitempty" jsonschema:"description=Whether to include the affected items in the response. This will include all items that were modified as well as their children.,default=true,required=false"`
-	Columns      []*orgmcp.Column `json:"columns,omitempty" jsonschema:"description=List of columns to include in the output. If not specified defaults to [UID ; PREVIEW]."`
+	Texts        []mcp.OneOf[*TextInputUnion] `json:"texts" jsonschema:"description=The list of text modifications to perform"`
+	Path         string                       `json:"path,omitempty" jsonschema:"description=The path to the Org file to modify; if not provided it will default to the current workspace file,required=false"`
+	ShowDiff     bool                         `json:"show_diff,omitempty" jsonschema:"description=Whether to show a diff of the changes made; default is false,default=false"`
+	ShowAffected *bool                        `json:"show_affected,omitempty" jsonschema:"description=Whether to include the affected items in the response. This will include all items that were modified as well as their children.,default=true,required=false"`
+	Columns      []*orgmcp.Column             `json:"columns,omitempty" jsonschema:"description=List of columns to include in the output. If not specified defaults to [UID ; PREVIEW]."`
 }
 
-type TextInputValue struct {
-	Uid     string `json:"uid" jsonschema:"description=The UID of the element to modify. This can be either a header or a bullet point. When adding text content the UID will refer to the parent element under which the text will be added."`
-	Method  string `json:"method" jsonschema:"description=The method of modification to perform (add; update or remove). When adding text content the method must be 'add'.;enum=add;update;remove"`
-	Content string `json:"content,omitempty" jsonschema:"description=The text content to add or update. When using the 'remove' method this field is ignored."`
+type TextInputUnion struct {
+	tag string
+
+	Add    TextInputAdd
+	Update TextInputUpdate
+	Remove TextInputRemove
+}
+
+func NewTextInputUnion[T TextInputAdd | TextInputUpdate | TextInputRemove](input T) *TextInputUnion {
+	switch any(input).(type) {
+	case TextInputAdd:
+		return &TextInputUnion{
+			tag: "add",
+			Add: any(input).(TextInputAdd),
+		}
+	case TextInputUpdate:
+		return &TextInputUnion{
+			tag:    "update",
+			Update: any(input).(TextInputUpdate),
+		}
+	case TextInputRemove:
+		return &TextInputUnion{
+			tag:    "remove",
+			Remove: any(input).(TextInputRemove),
+		}
+	default:
+		panic(fmt.Sprintf("unsupported type for TextInputUnion: %s", reflect.TypeOf(input)))
+	}
+}
+
+func NewTextInputUnionUpdate(update TextInputUpdate) TextInputUnion {
+	return TextInputUnion{
+		tag:    "update",
+		Update: update,
+	}
+}
+
+func NewTextInputUnionRemove(remove TextInputRemove) TextInputUnion {
+	return TextInputUnion{
+		tag:    "remove",
+		Remove: remove,
+	}
+}
+
+func (t *TextInputUnion) Value() any {
+	switch t.tag {
+	case "add":
+		return t.Add
+	case "update":
+		return t.Update
+	default:
+		return nil
+	}
+}
+
+func (t *TextInputUnion) Tag() string {
+	return t.tag
+}
+
+func (t *TextInputUnion) FromJSON(data []byte) error {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	switch raw["method"] {
+	case "add":
+		fallthrough
+	case nil:
+		t.tag = "add"
+		return json.Unmarshal(data, &t.Add)
+	case "update":
+		t.tag = "update"
+		return json.Unmarshal(data, &t.Update)
+	case "remove":
+		t.tag = "remove"
+		return json.Unmarshal(data, &t.Remove)
+	default:
+		return fmt.Errorf("invalid method: %s", raw["method"])
+	}
+}
+
+type TextInputAdd struct {
+	Method  string `json:"method" jsonschema:"description=Add new text content under the specified parent element.,enum=add"`
+	Parent  string `json:"parent" jsonschema:"description=The UID of the parent element under which the text will be added. This can be either a header or a bullet point."`
+	Content string `json:"content" jsonschema:"description=The text content to add. Newlines will result in multiple plain text elements being added, one for each line of text."`
+}
+
+func (t *TextInputAdd) Apply(ctx context.Context, of *orgmcp.OrgFile) (res ApplyResult) {
+	res.affectedItems = make(map[orgmcp.Uid]orgmcp.Render)
+	parentUid, ok := of.GetUid(orgmcp.NewUid(t.Parent)).Split()
+
+	if !ok {
+		res.err = fmt.Errorf("Parent uid %s not found.", t.Parent)
+		return
+	}
+
+	for c := range strings.SplitSeq(t.Content, "\n") {
+		newPlainText := orgmcp.NewPlainText(c)
+		parentUid.AddChildren(&newPlainText)
+
+		res.affectedItems[newPlainText.Uid()] = &newPlainText
+	}
+
+	return
+}
+
+type TextInputUpdate struct {
+	Uid     string `json:"uid" jsonschema:"description=The UID of the element to modify or remove."`
+	Method  string `json:"method" jsonschema:"description=Update the content of a text element.,enum=update"`
+	Content string `json:"content,omitempty" jsonschema:"description=The new content of the text element."`
+}
+
+func (t *TextInputUpdate) Apply(ctx context.Context, of *orgmcp.OrgFile) (res ApplyResult) {
+	res.affectedItems = make(map[orgmcp.Uid]orgmcp.Render)
+	selected, ok := of.GetUid(orgmcp.NewUid(t.Uid)).Split()
+
+	if !ok {
+		res.err = fmt.Errorf("Item with uid %s not found in %s.", t.Uid, of.Name())
+		return
+	}
+	if strings.Contains(t.Content, "\n") {
+		res.err = fmt.Errorf("Content with newlines is not allowed for the update method, these will be replaced with spaces. If you want to add content with newlines you should use the 'add' method to add new text elements for each line of text.")
+		t.Content = strings.ReplaceAll(t.Content, "\n", " ")
+	}
+
+	if plain, ok := selected.(*orgmcp.PlainText); ok {
+		plain.SetContent(t.Content)
+		res.affectedItems[plain.Uid()] = plain
+	} else {
+		res.err = fmt.Errorf("Uid %s is not a plain text element, cannot update content", t.Uid)
+	}
+
+	return
+}
+
+type TextInputRemove struct {
+	Uid    string `json:"uid" jsonschema:"description=The UID of the element to modify or remove."`
+	Method string `json:"method" jsonschema:"description=Remove the text element.,enum=remove"`
+}
+
+func (t *TextInputRemove) Apply(ctx context.Context, of *orgmcp.OrgFile) (res ApplyResult) {
+	res.affectedItems = make(map[orgmcp.Uid]orgmcp.Render)
+	selected, ok := of.GetUid(orgmcp.NewUid(t.Uid)).Split()
+
+	if !ok {
+		res.err = fmt.Errorf("Item with uid %s not found in %s.", t.Uid, of.Name())
+		return
+	}
+
+	p_uid := selected.ParentUid()
+	if parent, ok := of.GetUid(p_uid).Split(); ok {
+		parent.RemoveChildren(selected.Uid())
+		res.affectedItems[p_uid] = parent
+	} else {
+		res.err = fmt.Errorf("Parent with uid %s not found for item with uid %s", p_uid, t.Uid)
+	}
+
+	return
 }
 
 var TextTool = mcp.GenericTool[TextInputSchema]{
@@ -70,52 +227,23 @@ This can inform both you as well as the user about what exactly a tool call chan
 		affectedItems := map[orgmcp.Uid]orgmcp.Render{}
 
 		for _, mt := range input.Texts {
-			var selected orgmcp.Render
-			var ok bool
-			if selected, ok = orgFile.GetUid(orgmcp.NewUid(mt.Uid)).Split(); !ok {
-				resp = append(resp, fmt.Sprintf("Uid %s not found in %s", mt.Uid, path))
-				continue
-			}
+			var res ApplyResult
 
-			switch mt.Method {
+			switch mt.Value.Tag() {
 			case "add":
-				if strings.Contains(mt.Content, "\n") {
-					resp = append(resp, "Content for update method should not contain newlines. You should update each text element separately. As a fallback the newlines will be replaced with spaces.")
-					mt.Content = strings.ReplaceAll(mt.Content, "\n", " ")
-				}
-
-				newPlainText := orgmcp.NewPlainText(mt.Content)
-				selected.AddChildren(&newPlainText)
+				res = mt.Value.Add.Apply(ctx, &orgFile)
 			case "update":
-				if strings.Contains(mt.Content, "\n") {
-					resp = append(resp, "Content for update method should not contain newlines. You should update each text element separately. As a fallback the newlines will be replaced with spaces.")
-					mt.Content = strings.ReplaceAll(mt.Content, "\n", " ")
-				}
-
-				if plain, ok := selected.(*orgmcp.PlainText); ok {
-					plain.SetContent(mt.Content)
-					affectedItems[plain.Uid()] = plain
-					affectedCount += 1
-				} else {
-					resp = append(resp, fmt.Sprintf("Uid %s is not a plain text element, cannot update content", mt.Uid))
-				}
-
-				continue
+				res = mt.Value.Update.Apply(ctx, &orgFile)
 			case "remove":
-				p_uid := selected.ParentUid()
-				if parent, ok := orgFile.GetUid(p_uid).Split(); ok {
-					parent.RemoveChildren(selected.Uid())
-				} else {
-					resp = append(resp, fmt.Sprintf("Could not find parent for uid %s, skipping removal", mt.Uid))
-				}
+				res = mt.Value.Remove.Apply(ctx, &orgFile)
 			}
 
-			affectedItems[selected.Uid()] = selected
-			for _, child := range selected.ChildrenRec(-1) {
-				affectedItems[child.Uid()] = child
+			if res.err != nil {
+				resp = append(resp, res.err.Error())
 			}
 
-			affectedCount += 1
+			maps.Copy(affectedItems, res.affectedItems)
+			affectedCount += len(res.affectedItems)
 		}
 
 		ordered := []orgmcp.Render{}

--- a/tools/utils.go
+++ b/tools/utils.go
@@ -24,3 +24,8 @@ func GetDiffOnly(of orgmcp.OrgFile, filePath string) (res string, err error) {
 
 	return
 }
+
+type ApplyResult struct {
+	affectedItems map[orgmcp.Uid]orgmcp.Render
+	err           error
+}

--- a/tools/vector_search.go
+++ b/tools/vector_search.go
@@ -2,23 +2,23 @@ package tools
 
 import (
 	"context"
-	"strings"
+	"slices"
 
 	"github.com/p3rtang/org-mcp/mcp"
 	"github.com/p3rtang/org-mcp/orgmcp"
-	"github.com/p3rtang/org-mcp/utils/slice"
 )
 
 type VectorSearchInput struct {
-	Query string `json:"query" jsonschema:"description=The search query string.,required=true"`
-	TopN  int    `json:"top_n,omitempty" jsonschema:"description=The number of top relevant headers to return."`
-	Path  string `json:"path,omitempty" jsonschema:"description=An optional file path; will default to the configured org file. (./.tasks.org)"`
+	Query   string           `json:"query" jsonschema:"description=The search query string.,required=true"`
+	TopN    int              `json:"top_n,omitempty" jsonschema:"description=The number of top relevant headers to return."`
+	Path    string           `json:"path,omitempty" jsonschema:"description=An optional file path; will default to the configured org file. (./.tasks.org)"`
+	Columns []*orgmcp.Column `json:"columns,omitempty" jsonschema:"description=List of columns to include in the output. If not specified defaults to [UID | PREVIEW]."`
 }
 
 var VectorSearch = mcp.GenericTool[VectorSearchInput]{
 	Name: "vector_search",
 	Description: "Perform a vector search on all headers in the org file based on the provided query string. " +
-		"Returns the top N most relevant headers.\n" +
+		"Returns the top N most relevant headers, bullet, text or other element.\n" +
 		"It is optimal to include as much information as possible in the query, overflowing the text limit is hard. " +
 		"So include context like timeframes, people involved, locations, etc. to get the best results.",
 	Callback: func(ctx context.Context, input VectorSearchInput, options mcp.FuncOptions) (resp []any, err error) {
@@ -36,18 +36,14 @@ var VectorSearch = mcp.GenericTool[VectorSearchInput]{
 			return
 		}
 
-		headers, err := of.VectorSearch(input.Query, input.TopN)
+		locationTable := of.BuildLocationTable()
+		searchResults, err := of.VectorSearch(input.Query, input.TopN)
 
-		resp = append(resp, slice.Map(headers, func(r orgmcp.Render) map[string]any {
-			builder := strings.Builder{}
-			r.Render(&builder, 1)
+		slices.SortFunc(searchResults, func(a, b orgmcp.Render) int {
+			return (*locationTable)[a.Uid()] - (*locationTable)[b.Uid()]
+		})
 
-			return map[string]any{
-				"uid":        r.Uid().String(),
-				"content":    builder.String(),
-				"parent_uid": r.ParentUid().String(),
-			}
-		}))
+		resp = append(resp, orgmcp.PrintCsv(searchResults, input.Columns))
 
 		return
 	},


### PR DESCRIPTION
## Summary

Implements `oneOf` discriminated union support in the schema generator for MCP tools (Issue #18).

## Changes

### Schema Updates
All multi-operation tools now use `oneOf` discriminated unions for clear operation separation:

- **manage_text**: `add`, `update`, `remove` operations with `method` as discriminator
- **manage_bullet**: `add`, `update`, `remove` operations with `method` as discriminator  
- **manage_header**: `add`, `update`, `remove` operations with `method` as discriminator

### Key Design Decisions

1. **`method` as discriminator**: Each operation option includes a `method` field (`"add"`, `"update"`, `"remove"`) to clearly identify the operation type

2. **UID vs Parent distinction**:
   - `add` operations use `parent` (UID of parent element to add under)
   - `update`/`remove` operations use `uid` (UID of element itself)

3. **Minimal required fields**:
   - `add`: requires `method`, `parent`, `content`
   - `update`: requires `method`, `uid` (content optional)
   - `remove`: requires `method`, `uid` only

4. **Consistent patterns**:
   - `query_items`: Single operation with optional filters (no oneOf needed)
   - `status_overview`: Simple utility, no options needed
   - `vector_search`: Single operation with optional params

## Benefits

- Clear schema structure that AI models can understand
- Self-documenting - each option's purpose is explicit
- Reduces invalid field combinations
- Consistent across all CRUD tools

## Testing

All three tools (manage_text, manage_bullet, manage_header) have been tested:
- Add operations create new items correctly
- Update operations modify existing items correctly  
- Remove operations delete items correctly
- `affected_count` returns correct values

## Related Issues

- Closes #18
- Related to AI-native interaction patterns for structural integrity